### PR TITLE
Fix missing tabs permission and clarify build output

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,5 +12,5 @@
   "background": {
     "service_worker": "dist/background.js"
   },
-  "permissions": []
+  "permissions": ["tabs"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,8 @@ import { resolve } from 'path';
 export default defineConfig({
   root: 'extension',
   build: {
-    outDir: 'dist',
+    // Explicitly resolve output directory to the extension/dist folder
+    outDir: '../extension/dist',
     emptyOutDir: true,
     rollupOptions: {
       input: {


### PR DESCRIPTION
## Summary
- add `tabs` permission to `manifest.json` so the popup can query browser tabs
- clarify the build output path in `vite.config.ts`

## Testing
- `yarn build`
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_b_688c7b9e8bac832fb00821d4d029cff6