### PR TITLE
Add onboarding flow

### DIFF
--- a/extension/src/popup.tsx
+++ b/extension/src/popup.tsx
@@ -1,12 +1,15 @@
 import React, { Suspense, lazy } from 'react'
 import ReactDOM from 'react-dom/client'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { RoutePaths } from './routes/paths'
 import { Provider } from 'react-redux'
 import { TamaguiProvider, Theme } from 'tamagui'
 import tamaguiConfig from './tamagui.config'
 import store from './store'
 
 const Home = lazy(() => import('./routes/Home'))
+const OnboardingStart = lazy(() => import('./routes/onboarding/Start'))
+const OnboardingEnterAddress = lazy(() => import('./routes/onboarding/EnterAddress'))
 
 const App = () => (
   <Provider store={store}>
@@ -15,7 +18,9 @@ const App = () => (
         <Suspense fallback={<div>Loading...</div>}>
           <MemoryRouter>
             <Routes>
-              <Route path="/" element={<Home />} />
+              <Route path={RoutePaths.HOME} element={<Home />} />
+              <Route path={RoutePaths.ONBOARDING_START} element={<OnboardingStart />} />
+              <Route path={RoutePaths.ONBOARDING_ENTER_ADDRESS} element={<OnboardingEnterAddress />} />
             </Routes>
           </MemoryRouter>
         </Suspense>

--- a/extension/src/routes/Home.tsx
+++ b/extension/src/routes/Home.tsx
@@ -1,5 +1,13 @@
 import React from 'react'
+import { useNavigate } from 'react-router-dom'
+import { RoutePaths } from './paths'
 
 export default function Home() {
-  return <h1>Welcome to Safe Extension</h1>
+  const navigate = useNavigate()
+  return (
+    <div>
+      <h1>Welcome to Safe Extension</h1>
+      <button onClick={() => navigate(RoutePaths.ONBOARDING_START)}>Get started</button>
+    </div>
+  )
 }

--- a/extension/src/routes/onboarding/EnterAddress.tsx
+++ b/extension/src/routes/onboarding/EnterAddress.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+
+export default function EnterAddress() {
+  return (
+    <div>
+      <label>
+        Enter your Safe or signer address
+        <input type="text" />
+      </label>
+    </div>
+  )
+}

--- a/extension/src/routes/onboarding/EnterAddress.tsx
+++ b/extension/src/routes/onboarding/EnterAddress.tsx
@@ -3,10 +3,17 @@ import React from 'react'
 export default function EnterAddress() {
   return (
     <div>
-      <label>
+      <label htmlFor="address-input">
         Enter your Safe or signer address
-        <input type="text" />
-      </label>
+        <input
+          type="text"
+         id="address-input"
+         placeholder="e.g., 0x1234...abcd"
+         required
+         pattern="^0x[a-fA-F0-9]{40}$"
+         title="Please enter a valid Ethereum address (42 characters starting with 0x)."
+       />
+     </label>
     </div>
   )
 }

--- a/extension/src/routes/onboarding/Start.tsx
+++ b/extension/src/routes/onboarding/Start.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+import { RoutePaths } from '../paths'
+
+export default function Start() {
+  const navigate = useNavigate()
+  return (
+    <div>
+      <h2>Welcome to Safe</h2>
+      <button onClick={() => navigate(RoutePaths.ONBOARDING_ENTER_ADDRESS)}>Already have a Safe?</button>
+      <button>Create a Safe</button>
+    </div>
+  )
+}

--- a/extension/src/routes/paths.ts
+++ b/extension/src/routes/paths.ts
@@ -1,0 +1,5 @@
+export enum RoutePaths {
+  HOME = '/',
+  ONBOARDING_START = '/onboarding',
+  ONBOARDING_ENTER_ADDRESS = '/onboarding/already-have-safe',
+}


### PR DESCRIPTION
## Summary
- organize routes under an onboarding folder
- add EnterAddress and Start onboarding routes
- add Get started button on the Home page
- extract route paths into a shared enum

## Testing
- `yarn lint`
- `yarn build`


------
https://chatgpt.com/codex/tasks/task_b_688c80ff3b68832fb53d746497a37415