### PR TITLE
Style routes with TamagUI grid layout

### DIFF
--- a/extension/src/routes/Home.tsx
+++ b/extension/src/routes/Home.tsx
@@ -1,13 +1,22 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { RoutePaths } from './paths'
+import { Stack, H1, Button } from 'tamagui'
 
 export default function Home() {
   const navigate = useNavigate()
   return (
-    <div>
-      <h1>Welcome to Safe Extension</h1>
-      <button onClick={() => navigate(RoutePaths.ONBOARDING_START)}>Get started</button>
-    </div>
+    <Stack
+      display="grid"
+      gap="$4"
+      p="$4"
+      width="100%"
+      height="100%"
+      justifyContent="center"
+      alignContent="center"
+    >
+      <H1 textAlign="center">Welcome to Safe Extension</H1>
+      <Button onPress={() => navigate(RoutePaths.ONBOARDING_START)}>Get started</Button>
+    </Stack>
   )
 }

--- a/extension/src/routes/onboarding/EnterAddress.tsx
+++ b/extension/src/routes/onboarding/EnterAddress.tsx
@@ -1,19 +1,25 @@
 import React from 'react'
+import { Stack, Label, Input } from 'tamagui'
 
 export default function EnterAddress() {
   return (
-    <div>
-      <label htmlFor="address-input">
-        Enter your Safe or signer address
-        <input
-          type="text"
-         id="address-input"
-         placeholder="e.g., 0x1234...abcd"
-         required
-         pattern="^0x[a-fA-F0-9]{40}$"
-         title="Please enter a valid Ethereum address (42 characters starting with 0x)."
-       />
-     </label>
-    </div>
+    <Stack
+      display="grid"
+      gap="$4"
+      p="$4"
+      width="100%"
+      height="100%"
+      justifyContent="center"
+      alignContent="center"
+    >
+      <Label htmlFor="address-input">Enter your Safe or signer address</Label>
+      <Input
+        id="address-input"
+        placeholder="e.g., 0x1234...abcd"
+        required
+        pattern="^0x[a-fA-F0-9]{40}$"
+        title="Please enter a valid Ethereum address (42 characters starting with 0x)."
+      />
+    </Stack>
   )
 }

--- a/extension/src/routes/onboarding/Start.tsx
+++ b/extension/src/routes/onboarding/Start.tsx
@@ -1,14 +1,27 @@
 import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { RoutePaths } from '../paths'
+import { Stack, H2, Button, XStack } from 'tamagui'
 
 export default function Start() {
   const navigate = useNavigate()
   return (
-    <div>
-      <h2>Welcome to Safe</h2>
-      <button onClick={() => navigate(RoutePaths.ONBOARDING_ENTER_ADDRESS)}>Already have a Safe?</button>
-      <button>Create a Safe</button>
-    </div>
+    <Stack
+      display="grid"
+      gap="$4"
+      p="$4"
+      width="100%"
+      height="100%"
+      justifyContent="center"
+      alignContent="center"
+    >
+      <H2 textAlign="center">Welcome to Safe</H2>
+      <XStack space="$2" justifyContent="center">
+        <Button onPress={() => navigate(RoutePaths.ONBOARDING_ENTER_ADDRESS)}>
+          Already have a Safe?
+        </Button>
+        <Button>Create a Safe</Button>
+      </XStack>
+    </Stack>
   )
 }


### PR DESCRIPTION
## Summary
- replace HTML markup in popup routes with TamagUI components
- center content and add spacing using Stack-based grid layouts
- present onboarding flow with TamagUI buttons and inputs

## Testing
- `yarn lint && echo "Lint OK"`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_688dccdc9ca8832f906ef5a5d84aae1c