### PR TITLE
Define Tamagui spacing tokens to prevent runtime errors

### DIFF
--- a/extension/src/tamagui.config.ts
+++ b/extension/src/tamagui.config.ts
@@ -6,4 +6,15 @@ export default createTamagui({
     light: {},
     dark: {},
   },
+  // Define basic spacing tokens to avoid runtime errors when components
+  // reference values like `$4` for padding or gap.
+  tokens: {
+    space: {
+      0: 0,
+      1: 4,
+      2: 8,
+      3: 12,
+      4: 16,
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- define basic spacing tokens in Tamagui config

## Testing
- `npx eslint extension/src/tamagui.config.ts -f json`
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_b_688df3f3b0bc832f97bc4733a5e79b20