### PR TITLE
Fetch and display safes across chains

### DIFF
--- a/extension/src/routes/onboarding/EnterAddress.tsx
+++ b/extension/src/routes/onboarding/EnterAddress.tsx
@@ -1,7 +1,34 @@
-import React from 'react'
-import { Stack, Label, Input } from 'tamagui'
+import React, { useEffect, useMemo, useState } from 'react'
+import { Stack, Label, Input, XStack, Paragraph, Image } from 'tamagui'
+import { apiSliceWithChainsConfig, chainsAdapter } from '@safe-global/store/src/gateway/chains'
+import { useLazySafesGetOverviewForManyQuery } from '@safe-global/store/src/gateway/safes'
 
 export default function EnterAddress() {
+  const [address, setAddress] = useState('')
+  const { data: chainsState } = apiSliceWithChainsConfig.useGetChainsConfigQuery()
+  const [fetchSafes, { data: safesData }] = useLazySafesGetOverviewForManyQuery()
+
+  const chains = chainsState ? chainsAdapter.getSelectors().selectAll(chainsState) : []
+
+  useEffect(() => {
+    if (/^0x[a-fA-F0-9]{40}$/.test(address) && chains.length > 0) {
+      const safesParam = chains.map((chain) => `${chain.chainId}:${address}`)
+      fetchSafes({ safes: safesParam })
+    }
+  }, [address, chains, fetchSafes])
+
+  const groupedSafes = useMemo(() => {
+    if (!safesData) return {}
+    return safesData.reduce((acc, safe) => {
+      const safeAddress = safe.address.value
+      if (!acc[safeAddress]) {
+        acc[safeAddress] = []
+      }
+      acc[safeAddress].push(safe.chainId)
+      return acc
+    }, {} as Record<string, string[]>)
+  }, [safesData])
+
   return (
     <Stack
       display="grid"
@@ -19,7 +46,20 @@ export default function EnterAddress() {
         required
         pattern="^0x[a-fA-F0-9]{40}$"
         title="Please enter a valid Ethereum address (42 characters starting with 0x)."
+        value={address}
+        onChange={(e) => setAddress(e.target.value)}
       />
+      {Object.entries(groupedSafes).map(([safeAddress, chainIds]) => (
+        <XStack key={safeAddress} alignItems="center" gap="$2">
+          <Paragraph>{safeAddress}</Paragraph>
+          {chainIds.map((id) => {
+            const chain = chains.find((c) => c.chainId === id)
+            return chain?.chainLogoUri ? (
+              <Image key={id} src={chain.chainLogoUri} width={16} height={16} alt={chain.chainName} />
+            ) : null
+          })}
+        </XStack>
+      ))}
     </Stack>
   )
 }

--- a/extension/src/store.ts
+++ b/extension/src/store.ts
@@ -1,19 +1,13 @@
-import { configureStore, createSlice } from '@reduxjs/toolkit'
+import { configureStore } from '@reduxjs/toolkit'
+import { cgwClient, setBaseUrl } from '@safe-global/store'
 
-const counterSlice = createSlice({
-  name: 'counter',
-  initialState: 0,
-  reducers: {
-    increment: (state) => state + 1
-  }
-})
-
-export const { increment } = counterSlice.actions
+setBaseUrl('https://safe-client.safe.global')
 
 const store = configureStore({
   reducer: {
-    counter: counterSlice.reducer
-  }
+    [cgwClient.reducerPath]: cgwClient.reducer,
+  },
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(cgwClient.middleware),
 })
 
 export type RootState = ReturnType<typeof store.getState>


### PR DESCRIPTION
## Summary
- integrate safe store API into app store
- query Safe info across supported chains when entering an address and show chain logos

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to resolve entry for package "@safe-global/store"; the package may have incorrect main/module/exports specified)*

------
https://chatgpt.com/codex/tasks/task_b_688df76a6b8c832fb3ecf904518af62a