### PR TITLE
Fix repeated safes fetch and add USD currency parameter

### DIFF
--- a/extension/src/routes/onboarding/EnterAddress.tsx
+++ b/extension/src/routes/onboarding/EnterAddress.tsx
@@ -8,12 +8,15 @@ export default function EnterAddress() {
   const { data: chainsState } = apiSliceWithChainsConfig.useGetChainsConfigQuery()
   const [fetchSafes, { data: safesData }] = useLazySafesGetOverviewForManyQuery()
 
-  const chains = chainsState ? chainsAdapter.getSelectors().selectAll(chainsState) : []
+  const chains = useMemo(
+    () => (chainsState ? chainsAdapter.getSelectors().selectAll(chainsState) : []),
+    [chainsState],
+  )
 
   useEffect(() => {
     if (/^0x[a-fA-F0-9]{40}$/.test(address) && chains.length > 0) {
       const safesParam = chains.map((chain) => `${chain.chainId}:${address}`)
-      fetchSafes({ safes: safesParam })
+      fetchSafes({ safes: safesParam, currency: 'usd' })
     }
   }, [address, chains, fetchSafes])
 


### PR DESCRIPTION
## Summary
- revert custom chains pagination, rely on default chain config and memoize chain list to avoid redundant `/safes` overview calls
- include `currency=usd` when fetching safes overviews so values are denominated in USD

## Testing
- `yarn lint`


------
https://chatgpt.com/codex/tasks/task_b_688e12aafd70832fa859c1b6e3a5756d