### PR TITLE
Add Playwright E2E test for multi-chain Safe detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint \"extension/src/**/*.{ts,tsx}\""
+    "lint": "eslint \"extension/src/**/*.{ts,tsx}\"",
+    "test:e2e": "xvfb-run -a playwright test"
   },
   "keywords": [],
   "author": "",
@@ -16,6 +17,7 @@
     "@babel/core": "^7.28.0",
     "@babel/preset-env": "^7.28.0",
     "@babel/preset-react": "^7.27.1",
+    "@playwright/test": "^1.48.2",
     "@types/chrome": "^0.1.1",
     "@types/react": "^19.1.9",
     "@types/react-dom": "^19.1.7",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 120_000,
+  retries: 0,
+  expect: { timeout: 30_000 },
+  use: {
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+})

--- a/tests/already-have-safe.spec.js
+++ b/tests/already-have-safe.spec.js
@@ -1,0 +1,87 @@
+const { test, expect, chromium } = require('@playwright/test')
+const { execSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+// Build the extension before running tests
+let built = false
+function ensureBuilt() {
+  if (!built) {
+    execSync('yarn build', { stdio: 'inherit' })
+    const base = path.join(__dirname, '../extension')
+    fs.copyFileSync(path.join(base, 'manifest.json'), path.join(base, 'dist/manifest.json'))
+    if (fs.existsSync(path.join(base, 'icon.png'))) {
+      fs.copyFileSync(path.join(base, 'icon.png'), path.join(base, 'dist/icon.png'))
+    }
+    built = true
+  }
+}
+
+test.beforeAll(() => {
+  ensureBuilt()
+})
+
+test.describe.configure({ timeout: 120_000 })
+
+async function launchExtension() {
+  const extensionPath = path.join(__dirname, '../extension/dist')
+  const userDataDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pw-'))
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    headless: false,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  })
+
+  const extensionsDir = path.join(userDataDir, 'Default', 'Extensions')
+  let extensionId
+  for (let i = 0; i < 50 && !extensionId; i++) {
+    if (fs.existsSync(extensionsDir)) {
+      const entries = fs.readdirSync(extensionsDir)
+      if (entries.length > 0) {
+        extensionId = entries[0]
+        break
+      }
+    }
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  if (!extensionId) throw new Error('Extension ID not found')
+  const page = await context.newPage()
+  await page.goto(`chrome-extension://${extensionId}/popup.html`)
+  return { context, page }
+}
+
+// E2E test for the "Already have a Safe?" onboarding path
+// It navigates from the home page to the address entry screen
+
+test('navigates to the address entry screen', async () => {
+  const { context, page } = await launchExtension()
+
+  await page.getByRole('button', { name: 'Get started' }).click()
+  await page.getByRole('button', { name: 'Already have a Safe?' }).click()
+
+  await expect(
+    page.getByLabel('Enter your Safe or signer address')
+  ).toBeVisible()
+
+  await context.close()
+})
+
+test('detects Safe on two chains', async () => {
+  const { context, page } = await launchExtension()
+
+  await page.getByRole('button', { name: 'Get started' }).click()
+  await page.getByRole('button', { name: 'Already have a Safe?' }).click()
+
+  const address = '0xfE1DcF6cA7F39D9c5e86cE18a61276d36B490319'
+  const input = page.getByLabel('Enter your Safe or signer address')
+  await input.fill(address)
+
+  const safeRow = page.locator(`text=${address}`).locator('..')
+  await expect(safeRow).toBeVisible()
+  await expect(safeRow.getByRole('img')).toHaveCount(2)
+
+  await context.close()
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,6 +1663,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.48.2":
+  version: 1.54.2
+  resolution: "@playwright/test@npm:1.54.2"
+  dependencies:
+    playwright: "npm:1.54.2"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/a032d9714a91d6dc40405575ca65ec52f95b0ca95974cd0140e2c12b6c39fbe5311239b2d581b289acaa1e227dd871cf5c43a537f32457f6329723e4add6e6f1
+  languageName: node
+  linkType: hard
+
 "@react-native/normalize-color@npm:^2.1.0":
   version: 2.1.0
   resolution: "@react-native/normalize-color@npm:2.1.0"
@@ -5026,12 +5037,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -6432,6 +6462,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"playwright-core@npm:1.54.2":
+  version: 1.54.2
+  resolution: "playwright-core@npm:1.54.2"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/44850e20bf35237c8c3dedf1096c655f8af939dde53c5469f72cae3dd744966858a302419b909a73d7a2093323123e7ebcc0fdd55151b4193afb7812c1fd2c88
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.54.2":
+  version: 1.54.2
+  resolution: "playwright@npm:1.54.2"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.54.2"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/6f642fa70179eee5d5bf8a90df2a6147c9638ff926f4f3ad0a0517396b8a3fe00ccebf13377e032a75b3f0b2610ec1562293e0cfc3bde234181c7a50af8af80a
+  languageName: node
+  linkType: hard
+
 "possible-typed-array-names@npm:^1.0.0":
   version: 1.1.0
   resolution: "possible-typed-array-names@npm:1.1.0"
@@ -6936,6 +6990,7 @@ __metadata:
     "@babel/core": "npm:^7.28.0"
     "@babel/preset-env": "npm:^7.28.0"
     "@babel/preset-react": "npm:^7.27.1"
+    "@playwright/test": "npm:^1.48.2"
     "@reduxjs/toolkit": "npm:^2.8.2"
     "@safe-global/store": "github:safe-global/safe-wallet-monorepo#branch=dev&workspace=@safe-global/store"
     "@tamagui/animations-css": "npm:^1.132.15"


### PR DESCRIPTION
## Summary
- run Playwright E2E tests under xvfb and extend default timeouts
- copy manifest assets during build so the extension loads in tests
- add E2E test that pastes a Safe address and checks logos for two chains

## Testing
- `yarn lint`
- `yarn test:e2e` *(fails: Error: Extension ID not found)*

------
https://chatgpt.com/codex/tasks/task_b_688e12f253d8832f8804d3dc0c6ec110