### PR TITLE
Load signer safes in batches

### DIFF
--- a/tests/already-have-safe.spec.js
+++ b/tests/already-have-safe.spec.js
@@ -85,3 +85,21 @@ test('detects Safe on two chains', async () => {
 
   await context.close()
 })
+
+test('lists Safes for a signer address', async () => {
+  const { context, page } = await launchExtension()
+
+  await page.getByRole('button', { name: 'Get started' }).click()
+  await page.getByRole('button', { name: 'Already have a Safe?' }).click()
+
+  const signer = '0x474e5Ded6b5D078163BFB8F6dBa355C3aA5478C8'
+  const input = page.getByLabel('Enter your Safe or signer address')
+  await input.fill(signer)
+
+  const safeAddress = '0xfE1DcF6cA7F39D9c5e86cE18a61276d36B490319'
+  const safeRow = page.locator(`text=${safeAddress}`).locator('..')
+  await expect(safeRow).toBeVisible()
+  await expect(safeRow.getByRole('img')).toHaveCount(2)
+
+  await context.close()
+})


### PR DESCRIPTION
## Summary
- Fetch overviews for signer-owned safes using fetchSafes' built-in batching
- Stretch address entry field across the popup
- Display safes in a two-row grid with overlapping, right-aligned chain logos
- Add E2E test for entering a signer address

## Testing
- `npx eslint "extension/src/**/*.{ts,tsx}" && echo 'Lint passed'`
- `yarn test:e2e` *(fails: command not found: xvfb-run)*
- `yarn playwright install` *(fails: server returned code 403; missing host dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_688e5ff1b8a4832fb41aca06b5355581