### PR TITLE
feat: allow saving safes

### DIFF
--- a/extension/src/routes/onboarding/EnterAddress.tsx
+++ b/extension/src/routes/onboarding/EnterAddress.tsx
@@ -1,69 +1,13 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import { Stack, Label, Input, XStack, Paragraph, Image } from 'tamagui'
-import { apiSliceWithChainsConfig, chainsAdapter } from '@safe-global/store/src/gateway/chains'
-import { useLazySafesGetOverviewForManyQuery } from '@safe-global/store/src/gateway/safes'
-import { useLazyOwnersGetAllSafesByOwnerV2Query } from '@safe-global/store/src/gateway/AUTO_GENERATED/owners'
+import React, { useState } from 'react'
+import { Stack, Label, Input, Button } from 'tamagui'
+import SafeList from './components/SafeList'
+import { useDetectedSafes } from './hooks/useDetectedSafes'
+import { useSafeStorage } from './hooks/useSafeStorage'
 
 export default function EnterAddress() {
   const [address, setAddress] = useState('')
-  const { data: chainsState } = apiSliceWithChainsConfig.useGetChainsConfigQuery()
-  const [fetchSafes, { data: safesData }] = useLazySafesGetOverviewForManyQuery()
-  const [fetchOwnerSafes, { data: ownerSafesData }] = useLazyOwnersGetAllSafesByOwnerV2Query()
-
-  const chains = useMemo(
-    () => (chainsState ? chainsAdapter.getSelectors().selectAll(chainsState) : []),
-    [chainsState],
-  )
-
-  useEffect(() => {
-    if (/^0x[a-fA-F0-9]{40}$/.test(address) && chains.length > 0) {
-      const safesParam = chains.map((chain) => `${chain.chainId}:${address}`)
-      fetchSafes({ safes: safesParam, currency: 'usd' })
-    }
-  }, [address, chains, fetchSafes])
-
-  useEffect(() => {
-    if (safesData && safesData.length === 0) {
-      fetchOwnerSafes({ ownerAddress: address })
-    }
-  }, [safesData, address, fetchOwnerSafes])
-
-  useEffect(() => {
-    if (!ownerSafesData) return
-
-    const safesList = Object.entries(ownerSafesData).flatMap(([chainId, safes]) =>
-      safes.map((safeAddress) => `${chainId}:${safeAddress}`),
-    )
-
-    fetchSafes({ safes: safesList, currency: 'usd' })
-  }, [ownerSafesData, fetchSafes])
-
-  const groupedSafes = useMemo(() => {
-    if (ownerSafesData) {
-      return Object.entries(ownerSafesData).reduce((acc, [chainId, safes]) => {
-        safes.forEach((safeAddress) => {
-          if (!acc[safeAddress]) {
-            acc[safeAddress] = []
-          }
-          acc[safeAddress].push(chainId)
-        })
-        return acc
-      }, {} as Record<string, string[]>)
-    }
-
-    if (safesData && safesData.length > 0) {
-      return safesData.reduce((acc, safe) => {
-        const safeAddress = safe.address.value
-        if (!acc[safeAddress]) {
-          acc[safeAddress] = []
-        }
-        acc[safeAddress].push(safe.chainId)
-        return acc
-      }, {} as Record<string, string[]>)
-    }
-
-    return {}
-  }, [safesData, ownerSafesData])
+  const { chains, groupedSafes, isSigner } = useDetectedSafes(address)
+  const { saveSafe, saveAllSafes } = useSafeStorage()
 
   return (
     <Stack
@@ -86,26 +30,13 @@ export default function EnterAddress() {
         onChange={(e) => setAddress(e.target.value)}
         width="100%"
       />
-      {Object.entries(groupedSafes).map(([safeAddress, chainIds]) => (
-        <Stack key={safeAddress} display="grid" gridTemplateRows="auto auto" gap="$1">
-          <Paragraph>{safeAddress}</Paragraph>
-          <XStack justifyContent="flex-end">
-            {chainIds.map((id, index) => {
-              const chain = chains.find((c) => c.chainId === id)
-              return chain?.chainLogoUri ? (
-                <Image
-                  key={id}
-                  src={chain.chainLogoUri}
-                  width={16}
-                  height={16}
-                  alt={chain.chainName}
-                  ml={index === 0 ? 0 : -8}
-                />
-              ) : null
-            })}
-          </XStack>
-        </Stack>
-      ))}
+      {isSigner && <Button onPress={() => {}}>Import this signer</Button>}
+      <SafeList
+        groupedSafes={groupedSafes}
+        chains={chains}
+        onAdd={saveSafe}
+        onAddAll={() => saveAllSafes(groupedSafes)}
+      />
     </Stack>
   )
 }

--- a/extension/src/routes/onboarding/components/SafeItem.tsx
+++ b/extension/src/routes/onboarding/components/SafeItem.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Stack, Paragraph, Image, XStack, Button } from 'tamagui'
+import type { Chain } from '../hooks/useDetectedSafes'
+
+interface Props {
+  safeAddress: string
+  chainIds: string[]
+  chains: Chain[]
+  onAdd: (safeAddress: string, chainIds: string[]) => void
+}
+
+export default function SafeItem({
+  safeAddress,
+  chainIds,
+  chains,
+  onAdd,
+}: Props) {
+  return (
+    <Stack display="grid" gridTemplateRows="auto auto" gap="$1">
+      <Paragraph>{safeAddress}</Paragraph>
+      <XStack alignItems="center">
+        <XStack>
+          {chainIds.map((id, index) => {
+            const chain = chains.find((c) => c.chainId === id)
+            return chain?.chainLogoUri ? (
+              <Image
+                key={id}
+                src={chain.chainLogoUri}
+                width={16}
+                height={16}
+                alt={chain.chainName}
+                ml={index === 0 ? 0 : -8}
+              />
+            ) : null
+          })}
+        </XStack>
+        <Button ml="auto" onPress={() => onAdd(safeAddress, chainIds)}>
+          + Add
+        </Button>
+      </XStack>
+    </Stack>
+  )
+}

--- a/extension/src/routes/onboarding/components/SafeList.tsx
+++ b/extension/src/routes/onboarding/components/SafeList.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Button } from 'tamagui'
+import SafeItem from './SafeItem'
+import type { SaveSafe } from '../hooks/useSafeStorage'
+import type { Chain } from '../hooks/useDetectedSafes'
+
+interface Props {
+  groupedSafes: Record<string, string[]>
+  chains: Chain[]
+  onAdd: SaveSafe
+  onAddAll: () => void
+}
+
+export default function SafeList({ groupedSafes, chains, onAdd, onAddAll }: Props) {
+  const entries = Object.entries(groupedSafes)
+  if (entries.length === 0) return null
+
+  return (
+    <>
+      {entries.map(([safeAddress, chainIds]) => (
+        <SafeItem
+          key={safeAddress}
+          safeAddress={safeAddress}
+          chainIds={chainIds}
+          chains={chains}
+          onAdd={onAdd}
+        />
+      ))}
+      <Button onPress={onAddAll}>Add all</Button>
+    </>
+  )
+}

--- a/extension/src/routes/onboarding/hooks/useDetectedSafes.ts
+++ b/extension/src/routes/onboarding/hooks/useDetectedSafes.ts
@@ -1,0 +1,76 @@
+import { useEffect, useMemo } from 'react'
+import { apiSliceWithChainsConfig, chainsAdapter } from '@safe-global/store/src/gateway/chains'
+import { useLazySafesGetOverviewForManyQuery } from '@safe-global/store/src/gateway/safes'
+import { useLazyOwnersGetAllSafesByOwnerV2Query } from '@safe-global/store/src/gateway/AUTO_GENERATED/owners'
+
+export interface Chain {
+  chainId: string
+  chainLogoUri?: string
+  chainName: string
+}
+
+export const useDetectedSafes = (address: string) => {
+  const { data: chainsState } = apiSliceWithChainsConfig.useGetChainsConfigQuery()
+  const [fetchSafes, { data: safesData }] = useLazySafesGetOverviewForManyQuery()
+  const [fetchOwnerSafes, { data: ownerSafesData }] =
+    useLazyOwnersGetAllSafesByOwnerV2Query()
+
+  const chains: Chain[] = useMemo(
+    () => (chainsState ? chainsAdapter.getSelectors().selectAll(chainsState) : []),
+    [chainsState],
+  )
+
+  useEffect(() => {
+    if (/^0x[a-fA-F0-9]{40}$/.test(address) && chains.length > 0) {
+      const safesParam = chains.map((chain) => `${chain.chainId}:${address}`)
+      fetchSafes({ safes: safesParam, currency: 'usd' })
+    }
+  }, [address, chains, fetchSafes])
+
+  useEffect(() => {
+    if (safesData && safesData.length === 0) {
+      fetchOwnerSafes({ ownerAddress: address })
+    }
+  }, [safesData, address, fetchOwnerSafes])
+
+  useEffect(() => {
+    if (!ownerSafesData) return
+
+    const safesList = Object.entries(ownerSafesData).flatMap(([chainId, safes]) =>
+      safes.map((safeAddress) => `${chainId}:${safeAddress}`),
+    )
+
+    fetchSafes({ safes: safesList, currency: 'usd' })
+  }, [ownerSafesData, fetchSafes])
+
+  const groupedSafes = useMemo(() => {
+    if (ownerSafesData) {
+      return Object.entries(ownerSafesData).reduce((acc, [chainId, safes]) => {
+        safes.forEach((safeAddress) => {
+          if (!acc[safeAddress]) {
+            acc[safeAddress] = []
+          }
+          acc[safeAddress].push(chainId)
+        })
+        return acc
+      }, {} as Record<string, string[]>)
+    }
+
+    if (safesData && safesData.length > 0) {
+      return safesData.reduce((acc, safe) => {
+        const safeAddress = safe.address.value
+        if (!acc[safeAddress]) {
+          acc[safeAddress] = []
+        }
+        acc[safeAddress].push(safe.chainId)
+        return acc
+      }, {} as Record<string, string[]>)
+    }
+
+    return {}
+  }, [safesData, ownerSafesData])
+
+  const isSigner = !!ownerSafesData && Object.keys(ownerSafesData).length > 0
+
+  return { chains, groupedSafes, isSigner }
+}

--- a/extension/src/routes/onboarding/hooks/useSafeStorage.ts
+++ b/extension/src/routes/onboarding/hooks/useSafeStorage.ts
@@ -1,0 +1,40 @@
+import { useCallback } from 'react'
+
+const getStoredSafes = (): Promise<Record<string, string[]>> =>
+  new Promise((resolve) => {
+    chrome.storage.local.get(['safes'], (result) => {
+      resolve((result.safes as Record<string, string[]>) || {})
+    })
+  })
+
+const setStoredSafes = (safes: Record<string, string[]>): Promise<void> =>
+  new Promise((resolve) => {
+    chrome.storage.local.set({ safes }, () => resolve())
+  })
+
+export const useSafeStorage = () => {
+  const saveSafe = useCallback(async (safeAddress: string, chainIds: string[]) => {
+    const stored = await getStoredSafes()
+    stored[safeAddress] = Array.from(
+      new Set([...(stored[safeAddress] || []), ...chainIds]),
+    )
+    await setStoredSafes(stored)
+  }, [])
+
+  const saveAllSafes = useCallback(async (groupedSafes: Record<string, string[]>) => {
+    const stored = await getStoredSafes()
+    Object.entries(groupedSafes).forEach(([safeAddress, ids]) => {
+      stored[safeAddress] = Array.from(
+        new Set([...(stored[safeAddress] || []), ...ids]),
+      )
+    })
+    await setStoredSafes(stored)
+  }, [])
+
+  return { saveSafe, saveAllSafes }
+}
+
+export type SaveSafe = (
+  safeAddress: string,
+  chainIds: string[],
+) => Promise<void>


### PR DESCRIPTION
## Summary
- replace localStorage with extension storage
- move Safe detection and storage logic into reusable hooks
- split Safe list rendering into dedicated components

## Testing
- `yarn lint`
- `yarn test:e2e` *(fails: browser dependencies missing)*

------
https://chatgpt.com/codex/tasks/task_b_688f0c0fbed4832fb36e7482e584da6e