### PR TITLE
Add saved safes list and dashboard view

### DIFF
--- a/extension/src/components/SavedSafesList.tsx
+++ b/extension/src/components/SavedSafesList.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button, Paragraph, Image, XStack, Stack } from 'tamagui'
+import type { Chain } from '../routes/onboarding/hooks/useDetectedSafes'
+
+interface Props {
+  safes: Record<string, string[]>
+  chains: Chain[]
+}
+
+export default function SavedSafesList({ safes, chains }: Props) {
+  const navigate = useNavigate()
+  const entries = Object.entries(safes)
+  if (entries.length === 0) return null
+  return (
+    <Stack display="grid" gap="$2">
+      {entries.map(([safeAddress, chainIds]) => (
+        <Button
+          key={safeAddress}
+          onPress={() => navigate(`/dashboard/${safeAddress}`)}
+          justifyContent="flex-start"
+        >
+          <XStack alignItems="center" width="100%">
+            <Paragraph>{safeAddress}</Paragraph>
+            <XStack ml="auto">
+              {chainIds.map((id, index) => {
+                const chain = chains.find((c) => c.chainId === id)
+                return chain?.chainLogoUri ? (
+                  <Image
+                    key={id}
+                    src={chain.chainLogoUri}
+                    width={16}
+                    height={16}
+                    alt={chain.chainName}
+                    ml={index === 0 ? 0 : -8}
+                  />
+                ) : null
+              })}
+            </XStack>
+          </XStack>
+        </Button>
+      ))}
+    </Stack>
+  )
+}

--- a/extension/src/popup.tsx
+++ b/extension/src/popup.tsx
@@ -10,6 +10,7 @@ import store from './store'
 const Home = lazy(() => import('./routes/Home'))
 const OnboardingStart = lazy(() => import('./routes/onboarding/Start'))
 const OnboardingEnterAddress = lazy(() => import('./routes/onboarding/EnterAddress'))
+const Dashboard = lazy(() => import('./routes/Dashboard'))
 
 const App = () => (
   <Provider store={store}>
@@ -21,6 +22,7 @@ const App = () => (
               <Route path={RoutePaths.HOME} element={<Home />} />
               <Route path={RoutePaths.ONBOARDING_START} element={<OnboardingStart />} />
               <Route path={RoutePaths.ONBOARDING_ENTER_ADDRESS} element={<OnboardingEnterAddress />} />
+              <Route path={RoutePaths.DASHBOARD} element={<Dashboard />} />
             </Routes>
           </MemoryRouter>
         </Suspense>

--- a/extension/src/routes/Dashboard.tsx
+++ b/extension/src/routes/Dashboard.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import { Stack, H2, Paragraph, Image, XStack } from 'tamagui'
+import { useSafeStorage } from './onboarding/hooks/useSafeStorage'
+import { useDetectedSafes } from './onboarding/hooks/useDetectedSafes'
+import { useLazySafesGetOverviewForManyQuery } from '@safe-global/store/src/gateway/safes'
+
+export default function Dashboard() {
+  const { address = '' } = useParams<{ address: string }>()
+  const { safes } = useSafeStorage()
+  const { chains } = useDetectedSafes('')
+  const chainIds = safes[address] || []
+  const [fetchSafes, { data: safesData }] = useLazySafesGetOverviewForManyQuery()
+
+  useEffect(() => {
+    if (address && chainIds.length > 0) {
+      const safesParam = chainIds.map((id) => `${id}:${address}`)
+      fetchSafes({ safes: safesParam, currency: 'usd' })
+    }
+  }, [address, chainIds, fetchSafes])
+
+  return (
+    <Stack display="grid" gap="$4" p="$4">
+      <H2>{address}</H2>
+      {safesData?.map((safe) => {
+        const chain = chains.find((c) => c.chainId === safe.chainId)
+        return (
+          <XStack key={safe.chainId} alignItems="center" space="$2">
+            {chain?.chainLogoUri && (
+              <Image
+                src={chain.chainLogoUri}
+                width={16}
+                height={16}
+                alt={chain.chainName}
+              />
+            )}
+            <Paragraph>
+              {chain?.chainName || safe.chainId}: {safe.threshold}/{safe.owners.length}, {safe.fiatTotal}$
+            </Paragraph>
+          </XStack>
+        )
+      })}
+    </Stack>
+  )
+}

--- a/extension/src/routes/Home.tsx
+++ b/extension/src/routes/Home.tsx
@@ -2,9 +2,14 @@ import React from 'react'
 import { useNavigate } from 'react-router-dom'
 import { RoutePaths } from './paths'
 import { Stack, H1, Button } from 'tamagui'
+import SavedSafesList from '../components/SavedSafesList'
+import { useSafeStorage } from './onboarding/hooks/useSafeStorage'
+import { useDetectedSafes } from './onboarding/hooks/useDetectedSafes'
 
 export default function Home() {
   const navigate = useNavigate()
+  const { safes } = useSafeStorage()
+  const { chains } = useDetectedSafes('')
   return (
     <Stack
       display="grid"
@@ -17,6 +22,7 @@ export default function Home() {
     >
       <H1 textAlign="center">Welcome to Safe Extension</H1>
       <Button onPress={() => navigate(RoutePaths.ONBOARDING_START)}>Get started</Button>
+      <SavedSafesList safes={safes} chains={chains} />
     </Stack>
   )
 }

--- a/extension/src/routes/onboarding/EnterAddress.tsx
+++ b/extension/src/routes/onboarding/EnterAddress.tsx
@@ -3,11 +3,12 @@ import { Stack, Label, Input, Button } from 'tamagui'
 import SafeList from './components/SafeList'
 import { useDetectedSafes } from './hooks/useDetectedSafes'
 import { useSafeStorage } from './hooks/useSafeStorage'
+import SavedSafesList from '../../components/SavedSafesList'
 
 export default function EnterAddress() {
   const [address, setAddress] = useState('')
   const { chains, groupedSafes, isSigner } = useDetectedSafes(address)
-  const { saveSafe, saveAllSafes } = useSafeStorage()
+  const { saveSafe, saveAllSafes, safes } = useSafeStorage()
 
   return (
     <Stack
@@ -31,6 +32,7 @@ export default function EnterAddress() {
         width="100%"
       />
       {isSigner && <Button onPress={() => {}}>Import this signer</Button>}
+      <SavedSafesList safes={safes} chains={chains} />
       <SafeList
         groupedSafes={groupedSafes}
         chains={chains}

--- a/extension/src/routes/onboarding/components/SafeItem.tsx
+++ b/extension/src/routes/onboarding/components/SafeItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Stack, Paragraph, Image, XStack, Button } from 'tamagui'
 import type { Chain } from '../hooks/useDetectedSafes'
 
@@ -15,6 +15,7 @@ export default function SafeItem({
   chains,
   onAdd,
 }: Props) {
+  const [isSaved, setIsSaved] = useState(false)
   return (
     <Stack display="grid" gridTemplateRows="auto auto" gap="$1">
       <Paragraph>{safeAddress}</Paragraph>
@@ -34,8 +35,15 @@ export default function SafeItem({
             ) : null
           })}
         </XStack>
-        <Button ml="auto" onPress={() => onAdd(safeAddress, chainIds)}>
-          + Add
+        <Button
+          ml="auto"
+          disabled={isSaved}
+          onPress={async () => {
+            await onAdd(safeAddress, chainIds)
+            setIsSaved(true)
+          }}
+        >
+          {isSaved ? '✔️saved' : '+ Add'}
         </Button>
       </XStack>
     </Stack>

--- a/extension/src/routes/onboarding/hooks/useSafeStorage.ts
+++ b/extension/src/routes/onboarding/hooks/useSafeStorage.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 const getStoredSafes = (): Promise<Record<string, string[]>> =>
   new Promise((resolve) => {
@@ -13,12 +13,19 @@ const setStoredSafes = (safes: Record<string, string[]>): Promise<void> =>
   })
 
 export const useSafeStorage = () => {
+  const [storedSafes, setStoredSafesState] = useState<Record<string, string[]>>({})
+
+  useEffect(() => {
+    getStoredSafes().then(setStoredSafesState)
+  }, [])
+
   const saveSafe = useCallback(async (safeAddress: string, chainIds: string[]) => {
     const stored = await getStoredSafes()
     stored[safeAddress] = Array.from(
       new Set([...(stored[safeAddress] || []), ...chainIds]),
     )
     await setStoredSafes(stored)
+    setStoredSafesState(stored)
   }, [])
 
   const saveAllSafes = useCallback(async (groupedSafes: Record<string, string[]>) => {
@@ -29,9 +36,10 @@ export const useSafeStorage = () => {
       )
     })
     await setStoredSafes(stored)
+    setStoredSafesState(stored)
   }, [])
 
-  return { saveSafe, saveAllSafes }
+  return { safes: storedSafes, saveSafe, saveAllSafes }
 }
 
 export type SaveSafe = (

--- a/extension/src/routes/paths.ts
+++ b/extension/src/routes/paths.ts
@@ -2,4 +2,5 @@ export enum RoutePaths {
   HOME = '/',
   ONBOARDING_START = '/onboarding',
   ONBOARDING_ENTER_ADDRESS = '/onboarding/already-have-safe',
+  DASHBOARD = '/dashboard/:address',
 }


### PR DESCRIPTION
## Summary
- Track stored Safes and update add buttons to show ✔️saved
- List stored Safes on home and "already have a safe" pages
- Add dashboard route displaying fiat value and owner info per chain

## Testing
- `yarn lint` *(no output)*
- `yarn test:e2e` *(failed: chromium.launchPersistentContext ...)*
- `yarn playwright install` *(failed: 403 Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6891c051980c832f865bb792bfbc2b33