### PR TITLE
fix: persist saved safes across popup sessions

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -12,5 +12,5 @@
   "background": {
     "service_worker": "dist/background.js"
   },
-  "permissions": ["tabs"]
+  "permissions": ["tabs", "storage"]
 }

--- a/tests/saved-safes.spec.js
+++ b/tests/saved-safes.spec.js
@@ -1,0 +1,69 @@
+const { test, expect, chromium } = require('@playwright/test')
+const { execSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+let built = false
+function ensureBuilt() {
+  if (!built) {
+    execSync('yarn build', { stdio: 'inherit' })
+    const base = path.join(__dirname, '../extension')
+    fs.copyFileSync(path.join(base, 'manifest.json'), path.join(base, 'dist/manifest.json'))
+    if (fs.existsSync(path.join(base, 'icon.png'))) {
+      fs.copyFileSync(path.join(base, 'icon.png'), path.join(base, 'dist/icon.png'))
+    }
+    built = true
+  }
+}
+
+test.beforeAll(() => {
+  ensureBuilt()
+})
+
+test.describe.configure({ timeout: 120_000 })
+
+async function launchExtension() {
+  const extensionPath = path.join(__dirname, '../extension/dist')
+  const userDataDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'pw-'))
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    headless: false,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+    ],
+  })
+
+  const extensionsDir = path.join(userDataDir, 'Default', 'Extensions')
+  let extensionId
+  for (let i = 0; i < 50 && !extensionId; i++) {
+    if (fs.existsSync(extensionsDir)) {
+      const entries = fs.readdirSync(extensionsDir)
+      if (entries.length > 0) {
+        extensionId = entries[0]
+        break
+      }
+    }
+    await new Promise((r) => setTimeout(r, 100))
+  }
+  if (!extensionId) throw new Error('Extension ID not found')
+  const page = await context.newPage()
+  await page.goto(`chrome-extension://${extensionId}/popup.html`)
+  return { context, page }
+}
+
+test('shows saved safes after reopening popup', async () => {
+  const { context, page } = await launchExtension()
+
+  const safeAddress = '0x000000000000000000000000000000000000dead'
+  await page.evaluate((address) => {
+    return new Promise((resolve) => {
+      chrome.storage.local.set({ safes: { [address]: ['1'] } }, () => resolve())
+    })
+  }, safeAddress)
+
+  await page.reload()
+  await expect(page.getByText(safeAddress)).toBeVisible()
+
+  await context.close()
+})


### PR DESCRIPTION
## Summary
- add `storage` permission to manifest so saved safes persist across popup reloads
- add e2e test covering saved safes persistence

## Testing
- `yarn lint`
- `yarn test:e2e` *(fails: Playwright browsers could not be installed, 403 Domain forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6891cddbb2dc832facd6f30cd36addc9