### PR TITLE
feat: improve safe list navigation

### DIFF
--- a/extension/src/components/NavigationBar.tsx
+++ b/extension/src/components/NavigationBar.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
+import { XStack, Button } from 'tamagui'
+import { RoutePaths } from '../routes/paths'
+
+export default function NavigationBar() {
+  const navigate = useNavigate()
+  const location = useLocation()
+  const showBack = location.pathname !== RoutePaths.HOME
+
+  return (
+    <XStack alignItems="center" p="$2" borderBottomWidth={1} borderColor="$gray6">
+      {showBack && <Button size="$2" onPress={() => navigate(-1)}>Back</Button>}
+    </XStack>
+  )
+}

--- a/extension/src/popup.tsx
+++ b/extension/src/popup.tsx
@@ -3,7 +3,8 @@ import ReactDOM from 'react-dom/client'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { RoutePaths } from './routes/paths'
 import { Provider } from 'react-redux'
-import { TamaguiProvider, Theme } from 'tamagui'
+import { TamaguiProvider, Theme, Stack } from 'tamagui'
+import NavigationBar from './components/NavigationBar'
 import tamaguiConfig from './tamagui.config'
 import store from './store'
 
@@ -18,12 +19,15 @@ const App = () => (
       <Theme name="light">
         <Suspense fallback={<div>Loading...</div>}>
           <MemoryRouter>
-            <Routes>
-              <Route path={RoutePaths.HOME} element={<Home />} />
-              <Route path={RoutePaths.ONBOARDING_START} element={<OnboardingStart />} />
-              <Route path={RoutePaths.ONBOARDING_ENTER_ADDRESS} element={<OnboardingEnterAddress />} />
-              <Route path={RoutePaths.DASHBOARD} element={<Dashboard />} />
-            </Routes>
+            <Stack height="100%">
+              <NavigationBar />
+              <Routes>
+                <Route path={RoutePaths.HOME} element={<Home />} />
+                <Route path={RoutePaths.ONBOARDING_START} element={<OnboardingStart />} />
+                <Route path={RoutePaths.ONBOARDING_ENTER_ADDRESS} element={<OnboardingEnterAddress />} />
+                <Route path={RoutePaths.DASHBOARD} element={<Dashboard />} />
+              </Routes>
+            </Stack>
           </MemoryRouter>
         </Suspense>
       </Theme>

--- a/extension/src/routes/Dashboard.tsx
+++ b/extension/src/routes/Dashboard.tsx
@@ -12,6 +12,12 @@ export default function Dashboard() {
   const chainIds = safes[address] || []
   const [fetchSafes, { data: safesData }] = useLazySafesGetOverviewForManyQuery()
 
+  const formatFiatValue = (value: number) => {
+    const options: Intl.NumberFormatOptions = { notation: 'compact' }
+    options.maximumFractionDigits = value >= 1 ? 0 : 2
+    return new Intl.NumberFormat('en-US', options).format(value)
+  }
+
   useEffect(() => {
     if (address && chainIds.length > 0) {
       const safesParam = chainIds.map((id) => `${id}:${address}`)
@@ -35,7 +41,7 @@ export default function Dashboard() {
               />
             )}
             <Paragraph>
-              {chain?.chainName || safe.chainId}: {safe.threshold}/{safe.owners.length}, {safe.fiatTotal}$
+              {chain?.chainName || safe.chainId}: {safe.threshold}/{safe.owners.length}, {formatFiatValue(Number(safe.fiatTotal))}$
             </Paragraph>
           </XStack>
         )

--- a/extension/src/routes/onboarding/EnterAddress.tsx
+++ b/extension/src/routes/onboarding/EnterAddress.tsx
@@ -3,12 +3,11 @@ import { Stack, Label, Input, Button } from 'tamagui'
 import SafeList from './components/SafeList'
 import { useDetectedSafes } from './hooks/useDetectedSafes'
 import { useSafeStorage } from './hooks/useSafeStorage'
-import SavedSafesList from '../../components/SavedSafesList'
 
 export default function EnterAddress() {
   const [address, setAddress] = useState('')
   const { chains, groupedSafes, isSigner } = useDetectedSafes(address)
-  const { saveSafe, saveAllSafes, safes } = useSafeStorage()
+  const { saveSafe, saveAllSafes } = useSafeStorage()
 
   return (
     <Stack
@@ -32,7 +31,6 @@ export default function EnterAddress() {
         width="100%"
       />
       {isSigner && <Button onPress={() => {}}>Import this signer</Button>}
-      <SavedSafesList safes={safes} chains={chains} />
       <SafeList
         groupedSafes={groupedSafes}
         chains={chains}

--- a/extension/src/routes/onboarding/components/SafeItem.tsx
+++ b/extension/src/routes/onboarding/components/SafeItem.tsx
@@ -37,6 +37,7 @@ export default function SafeItem({
         </XStack>
         <Button
           ml="auto"
+          width={80}
           disabled={isSaved}
           onPress={async () => {
             await onAdd(safeAddress, chainIds)


### PR DESCRIPTION
## Summary
- keep saved safes list only on home screen
- keep Add button width stable and add navigation bar with Back button
- abbreviate dashboard fiat totals without cents over $1

## Testing
- `yarn lint`
- `yarn test:e2e` *(fails: Extension ID not found)*

------
https://chatgpt.com/codex/tasks/task_b_689381dbc0f4832f80d8f9ae52fa652b